### PR TITLE
Adding an AuthenticationException

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -84,6 +84,8 @@ module Prismic
 
         raise RefNotFoundException, "Ref #{ref} not found" if response.code == "404"
 
+        raise AuthenticationException, "Authentication error : #{response.body}" if response.code == "401" || response.code == "403"
+
         raise FormSearchException, "Error : #{response.body}" if response.code != "200"
 
         Prismic::JsonParser.results_parser(JSON.parse(response.body))
@@ -115,6 +117,7 @@ module Prismic
     class UnsupportedFormKind < Error ; end
     class RefNotFoundException < Error ; end
     class FormSearchException < Error ; end
+    class AuthenticationException < Error ; end
   end
 
   class Field


### PR DESCRIPTION
Ok with the AuthenticationException, but what I wanted to fix was the expired token issue in the Rails app (there are other reasons for the authentication to fail). Should I rather test the error message in the Rails controller? (I thought it would be better design to do it here, but that's ok with me)
