### PR TITLE
Views objects stored in a Hash and not an array

### DIFF
--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -67,8 +67,9 @@ module Prismic
         end
 
         main  = view_parser(json['value']['main'])
-        views = json['value']['views'].map do |name, view|
-          view_parser(view)
+        views = {}
+        json['value']['views'].each do |name, view|
+          views[name] = view_parser(view)
         end
 
         Prismic::Fragments::Image.new(main, views)

--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -166,9 +166,9 @@ json
     image.main.url.should == "url1"
     image.main.width.should == 500
     image.main.height.should == 500
-    image.views[0].url.should == "url2"
-    image.views[0].width.should == 250
-    image.views[0].height.should == 250
+    image.views['icon'].url.should == "url2"
+    image.views['icon'].width.should == 250
+    image.views['icon'].height.should == 250
   end
 end
 


### PR DESCRIPTION
Within an Image object, the Views were stored in an array instead of a hash, therefore:
- their view name was actually not stored anywhere in memory
- the method Prismic::Fragments::Image::get_view(name) did not work, throwing a NoMethodError `undefined method has_key? for #<Array:0x007fce2b1e1cd8>`

I fixed it and fixed the test, but now the way it is stored is quite changed, so it could break previous developments that might have been made with Ruby (I checked, it does not break the Rails starter kit, which only ever displays the main image). Should we merge it anyway?
