### PR TITLE
Implementation of the alt and copyright fields in image views

### DIFF
--- a/lib/prismic/fragments/image.rb
+++ b/lib/prismic/fragments/image.rb
@@ -26,12 +26,14 @@ module Prismic
       class ViewDoesNotExistException < Error ; end
 
       class View
-        attr_accessor :url, :width, :height
+        attr_accessor :url, :width, :height, :alt, :copyright
 
-        def initialize(url, width, height)
+        def initialize(url, width, height, alt = nil, copyright = nil)
           @url = url
           @width = width
           @height = height
+          @alt = alt
+          @copyright = copyright
         end
 
         def ratio
@@ -39,7 +41,7 @@ module Prismic
         end
 
         def as_html(link_resolver=nil)
-          %(<img src="#@url" width="#@width" height="#@height" />)
+          %(<img src="#@url")+(alt == nil ? "" : %( alt="#@alt"))+%( width="#@width" height="#@height" />)
         end
 
       end

--- a/lib/prismic/fragments/structured_text.rb
+++ b/lib/prismic/fragments/structured_text.rb
@@ -199,6 +199,14 @@ module Prismic
             @view.height
           end
 
+          def alt
+            @view.alt
+          end
+
+          def copyright
+            @view.copyright
+          end
+
           def as_html(link_resolver)
             view.as_html(link_resolver)
           end

--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -63,7 +63,9 @@ module Prismic
         def self.view_parser(json)
           Prismic::Fragments::Image::View.new(json['url'],
                                               json['dimensions']['width'],
-                                              json['dimensions']['height'])
+                                              json['dimensions']['height'],
+                                              json['alt'],
+                                              json['copyright'])
         end
 
         main  = view_parser(json['value']['main'])
@@ -127,7 +129,9 @@ module Prismic
             view = Prismic::Fragments::Image::View.new(
               block['url'],
               block['dimensions']['width'],
-              block['dimensions']['height']
+              block['dimensions']['height'],
+              block['alt'],
+              block['copyright']
             )
             Prismic::Fragments::StructuredText::Block::Image.new(view)
           when 'embed'

--- a/spec/fragments_spec.rb
+++ b/spec/fragments_spec.rb
@@ -300,12 +300,22 @@ describe 'Image::View' do
     it "returns an element whose `height` attribute equals the height" do
       Nokogiri::XML(@view.as_html).child.attribute('height').value.should == @height.to_s
     end
+
+    it "if set, returns an element whose `alt` attribute equals the alt" do
+      @alt = "Alternative text"
+      @view.alt = @alt
+      Nokogiri::XML(@view.as_html).child.attribute('alt').value.should == @alt
+    end
+
+    # it "if not set, alt attribute is absent" do
+    #   Nokogiri::XML(@view.as_html).child.attribute('alt').should == nil
+    # end
   end
 end
 
 describe 'Image' do
   before do
-    @main_view = Prismic::Fragments::Image::View.new('my_url', 10, 10)
+    @main_view = Prismic::Fragments::Image::View.new('my_url', 10, 10, "Alternative", "CC-BY")
     @another_view = Prismic::Fragments::Image::View.new('my_url2', 20, 20)
     @image = Prismic::Fragments::Image.new(@main_view, { 'another_view' => @another_view })
   end
@@ -330,6 +340,7 @@ describe 'Image' do
       Nokogiri::XML(@image.as_html).child.attribute('src').value.should == Nokogiri::XML(@main_view.as_html).child.attribute('src').value
       Nokogiri::XML(@image.as_html).child.attribute('width').value.should == Nokogiri::XML(@main_view.as_html).child.attribute('width').value
       Nokogiri::XML(@image.as_html).child.attribute('height').value.should == Nokogiri::XML(@main_view.as_html).child.attribute('height').value
+      Nokogiri::XML(@image.as_html).child.attribute('alt').value.should == Nokogiri::XML(@main_view.as_html).child.attribute('alt').value
     end
   end
 end
@@ -415,7 +426,7 @@ end
 
 describe 'StructuredText::Image' do
   before do
-    @view = Prismic::Fragments::Image::View.new('my_url', 10, 10)
+    @view = Prismic::Fragments::Image::View.new('my_url', 10, 10, "Aternative", "CC-BY")
     @image = Prismic::Fragments::StructuredText::Block::Image.new(@view)
   end
 
@@ -434,6 +445,18 @@ describe 'StructuredText::Image' do
   describe 'height' do
     it "returns the view's height" do
       @image.height.should == @view.height
+    end
+  end
+
+  describe 'alt' do
+    it "returns the view's alt" do
+      @image.alt.should == @view.alt
+    end
+  end
+
+  describe 'copyright' do
+    it "returns the view's copyright" do
+      @image.copyright.should == @view.copyright
     end
   end
 end

--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -141,6 +141,8 @@ describe 'image_parser' do
       "value": {
         "main": {
           "url": "url1",
+          "alt" : "Alternative",
+          "copyright" : "CC-BY",
           "dimensions": {
             "width": 500,
             "height": 500
@@ -149,6 +151,8 @@ describe 'image_parser' do
         "views": {
           "icon": {
             "url": "url2",
+            "alt" : "Alternative2",
+            "copyright" : "CC-0",
               "dimensions": {
                 "width": 250,
                 "height": 250
@@ -166,9 +170,13 @@ json
     image.main.url.should == "url1"
     image.main.width.should == 500
     image.main.height.should == 500
+    image.main.alt.should == "Alternative"
+    image.main.copyright.should == "CC-BY"
     image.views['icon'].url.should == "url2"
     image.views['icon'].width.should == 250
     image.views['icon'].height.should == 250
+    image.views['icon'].alt.should == "Alternative2"
+    image.views['icon'].copyright.should == "CC-0"
   end
 end
 

--- a/spec/responses_mocks/document.json
+++ b/spec/responses_mocks/document.json
@@ -56,6 +56,8 @@
         "value": {
           "main": {
             "url": "https://wroomio.s3.amazonaws.com/lesbonneschoses/0417110ebf2dc34a3e8b7b28ee4e06ac82473b70.png",
+            "alt" : "Alternative text to image",
+            "copyright" : "CC-BY",
             "dimensions": {
               "width": 500,
               "height": 500
@@ -64,6 +66,8 @@
           "views": {
             "icon": {
               "url": "https://wroomio.s3.amazonaws.com/lesbonneschoses/babdc3421037f9af77720d8f5dcf1b84c912c6ba.png",
+              "alt" : "Alternative text to view",
+              "copyright" : "CC-BY",
               "dimensions": {
                 "width": 250,
                 "height": 250

--- a/spec/responses_mocks/fragments.json
+++ b/spec/responses_mocks/fragments.json
@@ -60,6 +60,8 @@
         "value": {
           "main": {
             "url": "https://wroomio.s3.amazonaws.com/lesbonneschoses/0417110ebf2dc34a3e8b7b28ee4e06ac82473b70.png",
+            "alt" : "Alternative text to image",
+            "copyright" : "CC-BY",
             "dimensions": {
               "width": 500,
               "height": 500
@@ -68,6 +70,8 @@
           "views": {
             "icon": {
               "url": "https://wroomio.s3.amazonaws.com/lesbonneschoses/babdc3421037f9af77720d8f5dcf1b84c912c6ba.png",
+              "alt" : "Alternative text to view",
+              "copyright" : "CC-BY",
               "dimensions": {
                 "width": 250,
                 "height": 250


### PR DESCRIPTION
They are in the JSON, so I'm thinking, they could be useful.

``` json
{
  "main": {
    "url": "https://prismic-io.s3.amazonaws.com/lesbonneschoses/79a7a068ceb47892ac8de2480e878962d8b93cc6.png",
    "alt": "",
    "copyright": "",
    "dimensions": {
      "width": 500,
      "height": 500
    }
  },
  "views": {
    "icon": {
      "url": "https://prismic-io.s3.amazonaws.com/lesbonneschoses/b12819d149a0e6c6cd6717dba4b2c6a1bdafa9d4.png",
      "alt": "",
      "copyright": "",
      "dimensions": {
        "width": 250,
        "height": 250
      }
    }
  }
}
```

Of course, tested and all.
