### PR TITLE
getting link_resolver to work on a document

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -265,8 +265,13 @@ module Prismic
       @ref = ref
       @blk = blk
     end
-    def link_to(doc_link)
-      @blk.call(doc_link)
+    def link_to(doc)
+      if doc.is_a? Prismic::Fragments::DocumentLink
+        @blk.call(doc)
+      elsif doc.is_a? Prismic::Document
+        doc_link = Prismic::Fragments::DocumentLink.new(doc.id, doc.type, doc.tags, doc.slug, false)
+        @blk.call(doc_link)
+      end
     end
   end
 

--- a/spec/prismic_spec.rb
+++ b/spec/prismic_spec.rb
@@ -222,6 +222,25 @@ describe 'Api' do
 
 end
 
+describe 'LinkResolver' do
+  before do
+    @doc_link = Prismic::Fragments::DocumentLink.new('id', 'blog-post', ['tag1', 'tag2'], 'my-slug', false)
+    @document = Prismic::Document.new('id', 'blog-post', nil, ['tag1', 'tag2'], ['my-slug', 'my-other-slug'], nil)
+
+    @link_resolver = Prismic::LinkResolver.new(nil) do |doc|
+      '/'+doc.link_type+'/'+doc.id+'/'+doc.slug
+    end
+  end
+  
+  it "builds the right URL from a DocumentLink" do
+    @link_resolver.link_to(@doc_link).should == '/blog-post/id/my-slug'
+  end
+  
+  it "builds the right URL from a Document" do
+    @link_resolver.link_to(@document).should == '/blog-post/id/my-slug'
+  end
+end
+
 describe 'Document' do
   before do
     fragments = {


### PR DESCRIPTION
Trying to do this in a view (`@questions` is an array of `Prismic::Document` objects):

```
<% @questions.each do |question| %>
          <%= link_to "See the question", link_resolver(@ref).link_to(question) %>
<% end %>
```

Of course, this doesn't work, since LinkResolver.link_to takes a `DocumentLink`. Solutions: transforming it into a `DocumentLink` before passing it (meh), or redeveloping here the URL writing for questions, which I already wrote in my `link_resolver` helper method (meh, will have to change it on both places if my URLs change).

So, I'm thinking: maybe `link_to` should be able to handle `DocumentLink` and `Document` objects, so that we can do that? I developed it, and it works, but I'm not sure it's a behaviour we want for `link_resolver`; what do you think?
