### PR TITLE
Fix master_ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ There are two ways to get a better understanding at the kit:
 ##### Ruby kit's specificities
 
 This Ruby kit contains some mild differences or tips over [the "Kits and helpers" section of our API documentation](https://developers.prismic.io/documentation/UjBe8bGIJ3EKtgBZ/api-documentation#kits-and-helpers), which sets general information about how our kits work. They are listed here:
- * Retrieving the master ref from the API object is gotten by `api.master_ref` (rather than `api.master`).
  * From the api object, getting a form is done through the `create_search_form` method; a basic querying therefore looks like this: `api.create_search_form("everything").query(%([[:d = at(document.type, "product")]])).ref(@ref).submit()`.
  * When calling the API, a faster way to pass the `ref`: directly as a parameter of the `submit` method (no need to use the `ref` method then): `api.create_search_form("everything").submit(@ref)`.
  * Accessing type-dependent fields from a `document` is done through a `fragments` hash (rather than a `get()` method). Printing the HTML version of a field therefore looks like `document.fragments["title_user_friendly"].as_html(link_resolver(@ref)).html_safe`.

--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -2,7 +2,14 @@
 module Prismic
   class API
     attr_reader :json, :access_token, :http_client
-    attr_accessor :refs, :bookmarks, :forms, :master, :tags, :types, :oauth
+    attr_accessor :refs, :bookmarks, :forms, :tags, :types, :oauth
+
+    # Returns the master {Ref reference}
+    # @api
+    #
+    # @return [Ref] The master {Ref reference}
+    attr_accessor :master
+    alias :master_ref :master
 
     def initialize(json, access_token, http_client)
       @json = json
@@ -30,15 +37,6 @@ module Prismic
     def ref(name)
       refs[name.downcase]
     end
-
-    # Returns the master {Ref reference}
-    # @api
-    #
-    # @return [type] [description]
-    def master_ref
-      ref('master')
-    end
-
 
     def form(name)
       forms[name]

--- a/spec/prismic_spec.rb
+++ b/spec/prismic_spec.rb
@@ -46,6 +46,18 @@ describe 'Api' do
     end
   end
 
+  describe 'master_ref' do
+    it "returns the right Ref" do
+      @api.master_ref.label.should == 'label3'
+    end
+  end
+
+  describe 'master' do
+    it "returns the right Ref" do
+      @api.master.label.should == 'label3'
+    end
+  end
+
   describe 'form' do
     it "return the right Form" do
       @api.form('form2').name.should == 'form2'


### PR DESCRIPTION
The `master` method already existed and the `master_ref` method is buggy (it doesn't return the _master_ ref but the ref named “master”, which is not necessarily the _master_ ref).

This change replaces `master_ref` by an alias of `master` (to allow to use this method)  and change the document accordingly.
