### PR TITLE
Support for unknown types (ignores with warning)

### DIFF
--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'spec_helper'
+
 describe 'document_link_parser' do
   before do
     raw_json = <<json
@@ -324,5 +326,17 @@ json
     multiple.size.should == 2
     multiple[0].class.should == Prismic::Fragments::Text
     multiple[0].class.should == Prismic::Fragments::Text
+  end
+end
+
+describe 'unknown_parser' do
+  before do
+    @raw_json = File.read("#{File.dirname(__FILE__)}/responses_mocks/document_with_unknown_fragment.json")
+    @json = JSON.parse(@raw_json)
+  end
+
+  it "raises the proper error" do
+    Prismic::JsonParser.should_receive(:warn).with("Type blabla is unknown, fragment was skipped; perhaps you should update your prismic.io gem?")
+    Prismic::JsonParser.document_parser(@json).fragments.size.should == 2
   end
 end

--- a/spec/responses_mocks/document_with_unknown_fragment.json
+++ b/spec/responses_mocks/document_with_unknown_fragment.json
@@ -1,0 +1,37 @@
+{
+  "id": "UdUkXt_mqZBObPeS",
+  "type": "product",
+  "href": "doc-url",
+  "tags": [
+    "Macaron"
+  ],
+  "slugs": [
+    "vanilla-macaron"
+  ],
+  "data": {
+    "product": {
+      "name": {
+        "type": "StructuredText",
+        "value": [
+          {
+          "type": "heading1",
+          "text": "Vanilla Macaron",
+          "spans": []
+        }
+        ]
+      },
+      "short_lede": {
+        "type": "blabla",
+        "value": "foo"
+      },
+      "short_lede2": {
+        "type": "blabla",
+        "value": "foo"
+      },
+      "allergens": {
+        "type": "Text",
+        "value": "Contains almonds, eggs, milk"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Today, I added new "Group" fragments in my content repository's masks, and suddenly, some pages on my example website were not working anymore, with an obscure error (cannot execute "call" on nil, or something), even though I wasn't yet using those fragments in my views, nor did I touch anything in the code.
Reason: during the document parsing, when the kit encounters a type it doesn't know, it goes mad and raises an error.

With this fix, the parsing of an unknown fragment just ignores it; it also sends a warning once per unknown type, advising to update the gem.
