### PR TITLE
Support for Link.file and Link.image

### DIFF
--- a/lib/prismic/fragments/link.rb
+++ b/lib/prismic/fragments/link.rb
@@ -29,7 +29,23 @@ module Prismic
       end
     end
 
-    class MediaLink < Link
+    class FileLink < Link
+      attr_accessor :url, :name, :kind, :size
+
+      def initialize(url, name, kind, size)
+        @url = url
+        @name = name
+        @kind = kind
+        @size = size
+      end
+
+      def as_html(link_resolver=nil)
+        %(#{start_html(link_resolver)}#@name#{end_html(link_resolver)})
+      end
+
+    end
+
+    class ImageLink < Link
       attr_accessor :url
 
       def initialize(url)

--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -8,6 +8,8 @@ module Prismic
           'Link.document'  => method(:document_link_parser),
           'Text'           => method(:text_parser),
           'Link.web'       => method(:web_link_parser),
+          'Link.image'       => method(:image_link_parser),
+          'Link.file'       => method(:file_link_parser),
           'Date'           => method(:date_parser),
           'Number'         => method(:number_parser),
           'Embed'          => method(:embed_parser),
@@ -28,6 +30,14 @@ module Prismic
           doc['tags'],
           doc['slug'],
           json['value']['isBroken'])
+      end
+
+      def image_link_parser(json)
+        Prismic::Fragments::ImageLink.new(json['value']['image']['url'])
+      end
+
+      def file_link_parser(json)
+        Prismic::Fragments::FileLink.new(json['value']['file']['url'], json['value']['file']['name'], json['value']['file']['kind'], json['value']['file']['size'])
       end
 
       def text_parser(json)
@@ -209,6 +219,10 @@ module Prismic
           document_link_parser(json)
         elsif json['type'] == 'Link.web'
           web_link_parser(json)
+        elsif json['type'] == 'Link.image'
+          image_link_parser(json)
+        elsif json['type'] == 'Link.file'
+          file_link_parser(json)
         end
       end
     end

--- a/spec/fragments_spec.rb
+++ b/spec/fragments_spec.rb
@@ -34,35 +34,48 @@ describe 'WebLink' do
   end
 end
 
-describe 'MediaLink' do
+describe 'ImageLink' do
   before do
-    @media_link = Prismic::Fragments::MediaLink.new('my_url')
+    @image_link = Prismic::Fragments::ImageLink.new('my_url')
   end
 
   describe 'as_html' do
 
     it "returns an <a> HTML element" do
-      Nokogiri::XML(@media_link.as_html).child.name.should == 'a'
+      Nokogiri::XML(@image_link.as_html).child.name.should == 'a'
     end
 
     it "returns a HTML element with an href attribute" do
-      Nokogiri::XML(@media_link.as_html).child.has_attribute?('href').should be_true
+      Nokogiri::XML(@image_link.as_html).child.has_attribute?('href').should be_true
     end
 
     it "returns a HTML element with an href attribute pointing to the url" do
-      Nokogiri::XML(@media_link.as_html).child.attribute('href').value.should == 'my_url'
+      Nokogiri::XML(@image_link.as_html).child.attribute('href').value.should == 'my_url'
     end
 
     it "returns a HTML element whose content is the link" do
-      Nokogiri::XML(@media_link.as_html).child.content.should == 'my_url'
+      Nokogiri::XML(@image_link.as_html).child.content.should == 'my_url'
     end
   end
 
   describe 'as_text' do
     it 'raises an NotImplementedError' do
-      expect { @media_link.as_text }.to raise_error NotImplementedError
+      expect { @image_link.as_text }.to raise_error NotImplementedError
     end
   end
+end
+
+describe 'FileLink' do
+	describe 'in structured texts' do
+		before do
+			@raw_json_structured_text = File.read("#{File.dirname(__FILE__)}/responses_mocks/structured_text_linkfile.json")
+			@json_structured_text = JSON.parse(@raw_json_structured_text)
+			@structured_text = Prismic::JsonParser.structured_text_parser(@json_structured_text)
+		end
+		it 'serializes well into HTML' do
+			@structured_text.as_html(nil).should == "<p><a href=\"https://prismic-io.s3.amazonaws.com/annual.report.pdf\">2012 Annual Report</p>\n\n<p><a href=\"https://prismic-io.s3.amazonaws.com/annual.budget.pdf\">2012 Annual Budget</p>\n\n<p><a href=\"https://prismic-io.s3.amazonaws.com/vision.strategic.plan_.sm_.pdf\">2015 Vision &amp; Strategic Plan</p>"
+		end
+	end
 end
 
 describe 'Text' do

--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -199,6 +199,34 @@ json
   end
 end
 
+describe 'file_link_parser' do
+  before do
+    raw_json = <<json
+    {
+      "type": "Link.file",
+      "value": {
+        "file": {
+          "name": "2012_annual.report.pdf",
+          "kind": "document",
+          "url": "https://prismic-io.s3.amazonaws.com/annual.report.pdf",
+          "size": "1282484"
+        }
+      }
+    }
+json
+    @json = JSON.parse(raw_json)
+    @link_file = Prismic::JsonParser.file_link_parser(@json)
+  end
+
+  it 'correctly parses file links' do
+    @link_file.url.should == "https://prismic-io.s3.amazonaws.com/annual.report.pdf"
+    @link_file.kind.should == "document"
+    @link_file.name.should == "2012_annual.report.pdf"
+    @link_file.size.should == "1282484"
+    @link_file.as_html.should == "<a href=\"https://prismic-io.s3.amazonaws.com/annual.report.pdf\">2012_annual.report.pdf</a>"
+  end
+end
+
 describe 'structured_text_parser' do
   before do
     raw_json_paragraph = File.read("#{File.dirname(__FILE__)}/responses_mocks/structured_text_paragraph.json")

--- a/spec/responses_mocks/structured_text_linkfile.json
+++ b/spec/responses_mocks/structured_text_linkfile.json
@@ -1,0 +1,71 @@
+{
+  "type": "StructuredText",
+  "value": [
+    {
+      "type": "paragraph",
+      "text": "2012 Annual Report",
+      "spans": [
+        {
+          "start": 0,
+          "end": 18,
+          "type": "hyperlink",
+          "data": {
+            "type": "Link.file",
+            "value": {
+              "file": {
+                "name": "2012_annual.report.pdf",
+                "kind": "document",
+                "url": "https://prismic-io.s3.amazonaws.com/annual.report.pdf",
+                "size": "1282484"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "text": "2012 Annual Budget",
+      "spans": [
+        {
+          "start": 0,
+          "end": 18,
+          "type": "hyperlink",
+          "data": {
+            "type": "Link.file",
+            "value": {
+              "file": {
+                "name": "2012_smec.annual.budget.pdf",
+                "kind": "document",
+                "url": "https://prismic-io.s3.amazonaws.com/annual.budget.pdf",
+                "size": "59229"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "text": "2015 Vision & Strategic Plan",
+      "spans": [
+        {
+          "start": 0,
+          "end": 28,
+          "type": "hyperlink",
+          "data": {
+            "type": "Link.file",
+            "value": {
+              "file": {
+                "name": "2015_vision.strategic.plan_.sm_.pdf",
+                "kind": "document",
+                "url": "https://prismic-io.s3.amazonaws.com/vision.strategic.plan_.sm_.pdf",
+                "size": "1969956"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Pushing it as a pull-request and merging it, just so that @dohzya gets notified of the change.

Note: `Link.image` is not properly tested, but it makes more sense to do it once it's fixed on the API side (not 100% sure of the JSON syntax). Let's keep an eye open for people who might have issues with this particular fragment type.
