### PR TITLE
Cache issue, probably because ref is not in cache key

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -235,7 +235,7 @@ module Prismic
       raise NoRefSetException unless @ref
 
       # cache_key is a mix of HTTP URL and HTTP method
-      cache_key = form_method+'::'+form_action+'?'+data.map{|k,v|"#{k}=#{v}"}.join('&')
+      cache_key = form_method+'::'+form_action+'?'+data.map{|k,v|"#{k}=#{v}"}.join('&')+'?ref='+ref.ref
 
       api.caching(cache_key) {
         if form_method == "GET" && form_enctype == "application/x-www-form-urlencoded"

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -69,5 +69,18 @@ describe "Cache's" do
 				@cache.include?('fake_key2').should be_false
 			end
 		end
+
+		describe 'caching on a real repository' do
+			before do
+				@api = Prismic.api("https://lesbonneschoses.prismic.io/api", access_token: 'MC5VbDdXQmtuTTB6Z0hNWHF3.c--_vVbvv73vv73vv73vv71EA--_vS_vv73vv70T77-9Ke-_ve-_vWfvv70ebO-_ve-_ve-_vQN377-9ce-_vRfvv70')
+				@cache = @api.cache
+				@master_ref = @api.master_ref
+				@other_ref = @api.refs['announcement of new sf shop']
+			end
+			it 'works on different refs' do
+				@api.form('everything').submit(@master_ref).total_results_size.should == 40
+				@api.form('everything').submit(@other_ref).total_results_size.should == 43
+			end
+		end
 	end
 end


### PR DESCRIPTION
To reproduce it:
- do a query on a given ref
- do the same query on another ref

Both responses are the same, and are what should be returned by the first query.

I guess the ref is simply not a part of the cache key. I'll look at it today. We should ship it quickly.
