### PR TITLE
Adding aliases to be able to use Kaminari out of the box

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -310,6 +310,10 @@ module Prismic
   class Documents
     attr_accessor :page, :results_per_page, :results_size, :total_results_size, :total_pages, :next_page, :prev_page, :results
 
+    # To be able to use Kaminari as a paginator in Rails out of the box
+    alias :current_page :page
+    alias :limit_value :results_per_page
+
     def initialize(page, results_per_page, results_size, total_results_size, total_pages, next_page, prev_page, results)
       @page = page
       @results_per_page = results_per_page


### PR DESCRIPTION
So that pagination looks a bit more like this: https://github.com/rudyrigot/ruby-rails-starter/commit/5f96056ab5ecf8da4f3a358dc62c81794dedbbd8

(no worries, I won't merge that starter project's commit to master, considering how I altered the Gemfile for the prismic.io version; I'll fix it and PR it after this PR is merged)
