### PR TITLE
Fix API cache invalidation

### DIFF
--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -92,7 +92,7 @@ module Prismic
       data = {}
       data["access_token"] = access_token if access_token
       cache_key = url + (access_token ? ("#" + access_token) : "")
-      api_cache.get_or_set(cache_key, expired_in:5) {
+      api_cache.get_or_set(cache_key, nil, 5) {
         res = http_client.get(url, data, 'Accept' => 'application/json')
         case res.code
         when '200'

--- a/lib/prismic/cache/basic.rb
+++ b/lib/prismic/cache/basic.rb
@@ -39,7 +39,7 @@ module Prismic
     end
 
     def get_or_set(key, value = nil, expired_in = 0)
-      return get(key) if include?(key)
+      return get(key) if include?(key) && !expired?(key)
       set(key, block_given? ? yield : value, expired_in)
     end
 

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -100,6 +100,14 @@ describe "Basic Cache's" do
 	cache.get('key').should == nil
   end
 
+  it 'set with expiration and a block' do
+    cache = Prismic::BasicCache.new
+    cache.get_or_set('key', nil, 2){ 'value' }
+    cache.get_or_set('key', nil, 2){ 'othervalue' }.should == 'value'
+    sleep(3)
+    cache.get_or_set('key', nil, 2){ 'othervalue' }.should == 'othervalue'
+  end
+
   it 'set & test value' do
 	cache = Prismic::BasicCache.new
 	cache.set('key', 'value')


### PR DESCRIPTION
The bug came from two errors, fixed here:
- the method's signature is `get_or_set(key, value = nil, expired_in = 0)`, but during the /api endpoint caching, it was called like this: `api_cache.get_or_set(cache_key, expired_in:5) { do_something }`. This way of writing only works if the last parameter is a Hash, usually called `opt`, which isn't the case here; it isn't meant for optional parameters. [See more here](http://stackoverflow.com/questions/812058/ruby-optional-parameters).  So, the value for `expired_in` was always 0, which means "cache forever".
- the first line of the method was `return get(key) if include?(key)`, which was a problem when the key existed but was expired: the method would try to run `get` on it, which would first test if it was expired, and would therefore return `nil`. The solution was to `return get(key) if include?(key) && !expired?(key)`, so that the method doesn't try to run `get`, but would skip to the next line of code, which yields, as should be.
