### PR TITLE
- Fixed label not showing up in StructuredText(H2,List..etc)

### DIFF
--- a/lib/prismic/fragments/structured_text.rb
+++ b/lib/prismic/fragments/structured_text.rb
@@ -252,7 +252,7 @@ module Prismic
           attr_accessor :level
 
           def initialize(text, spans, level, label = nil)
-            super(text, spans)
+            super(text, spans,label)
             @level = level
           end
 
@@ -293,7 +293,7 @@ module Prismic
           alias :ordered? :ordered
 
           def initialize(text, spans, ordered, label = nil)
-            super(text, spans)
+            super(text, spans, label)
             @ordered = ordered
           end
 


### PR DESCRIPTION
Fix: The label didn't show up as class for Headings/List
