### PR TITLE
to_s raises Prismic::SearchForm::FormSearchException

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -308,9 +308,9 @@ module Prismic
       field = @form.fields[field_name]
       if field && field.repeatable?
         data[field_name] = [] unless data.include? field_name
-        data[field_name] << value.to_s
+        data[field_name] << value
       else
-        data[field_name] = value.to_s
+        data[field_name] = value
       end
       self
     end


### PR DESCRIPTION
Calling .to_s on value from a parameter that is nil raises Prismic::SearchForm::FormSearchException.  This affects index pages that are paginated.

@posts = @api.form('everything').
              query('[[:d = at(document.type, "article")]]')
              .orderings('[my.article.date desc]')
              .page(params[:page]).submit(@ref)

This works on http://localhost:3000/blog?page=1 but not http://localhost:3000/blog

The breaking change was introduced in 0c0e669567833f6d5adff46ba3e01c95754ddb81
