### PR TITLE
Added null api cache and ability to pass it in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Knowing all that, here is typical code written with the Ruby kit:
  * A typical fragment manipulation looks like this: `doc['article.image'].get_view('icon').url`
  * A typical fragment serialization to HTML looks like this: `doc['article.body'].as_html(@link_resolver)`
 
+#### Configuring Alternative API Caches
+
+It can be an advantage to have controll over both document and api caches.  The default api cache is perfect for development and production uses but can cause issues in certain test environments (such as using VCR to capture/replay Prismic.io interactions).  A null cache (does no caching) is available to be used as an alternative api cache.  To configure it (or any other compliant cache), simply add `api_cache => Prismic::BasicNullCache.new`
+to the options passed to `Prismic.api`.
+
 ### Changelog
 
 Need to see what changed, or to upgrade your kit? We keep our changelog on [this repository's "Releases" tab](https://github.com/prismicio/ruby-kit/releases).

--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -152,8 +152,10 @@ module Prismic
       http_client = opts[:http_client] || Prismic::DefaultHTTPClient
       access_token = opts[:access_token]
       cache = opts[:cache]
+      api_cache = opts[:api_cache]
+      api_cache = Prismic::DefaultApiCache unless api_cache
       cache ||= Prismic::DefaultCache unless !cache
-      resp = get(url, access_token, http_client)
+      resp = get(url, access_token, http_client, api_cache)
       json = JSON.load(resp.body)
       parse_api_response(json, access_token, http_client, cache)
     end

--- a/lib/prismic/cache/basic.rb
+++ b/lib/prismic/cache/basic.rb
@@ -63,4 +63,16 @@ module Prismic
   end
 
   DefaultApiCache = BasicCache.new
+  
+  # Available as an api cache for testing purposes (no caching)
+  class BasicNullCache
+    def get(key)
+    end
+
+    def set(key, value = nil, expired_in = nil)
+      block_given? ? yield : value
+    end
+    alias_method :get_or_set, :set
+
+  end
 end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -83,6 +83,18 @@ describe "Cache's" do
       end
     end
   end
+
+  describe 'configurable api cache' do
+    let(:api_cache) { Prismic::BasicNullCache.new }
+    it 'uses api_cache if provided' do
+      expect(api_cache).to receive(:get_or_set).with("https://lesbonneschoses.prismic.io/api", nil, 5).and_call_original.once
+      Prismic.api("https://lesbonneschoses.prismic.io/api", api_cache: api_cache)
+    end
+    it 'uses default cache if not provided' do
+      expect(Prismic::DefaultApiCache).to receive(:get_or_set).with("https://lesbonneschoses.prismic.io/api", nil, 5).and_call_original.once
+      Prismic.api("https://lesbonneschoses.prismic.io/api")
+    end
+  end
 end
 
 describe "Basic Cache's" do
@@ -145,5 +157,26 @@ describe "Basic Cache's" do
     cache.get('key').should == nil
     cache.get('key1').should == nil
     cache.get('key2').should == nil
+  end
+end
+
+describe 'BasicNullCache' do
+  subject { Prismic::BasicNullCache.new }
+  it 'always misses' do
+    subject.get('key').should == nil
+    subject.set('key', 'value').should == 'value'
+    subject.get('key').should == nil
+  end
+  it 'set uses value if no block' do
+    subject.set('key', 'value').should == 'value'
+  end
+  it 'set uses block if provided' do
+    subject.set('key', 'value'){'value2'}.should == 'value2'
+  end
+  it 'get_or_set uses value if no block' do
+    subject.get_or_set('key', 'value').should == 'value'
+  end
+  it 'get_or_set uses block if provided' do
+    subject.get_or_set('key', 'value'){'value2'}.should == 'value2'
   end
 end


### PR DESCRIPTION
## Summary

Some ruby projects use capture/playback (for example the VCR gem) of Prismic.io interactions in tests.  The current implementation does not allow configuration of the api cache.  This causes issues with maintaining playback sessions (e.g., vcr cassettes) because the reference mismatches and incomplete interactions (some won't have the api init call since it is cached in memory for 5 seconds).

This change simply exposes an additional parameter (optional) into the Prismic.api and a null cache (does no caching) which can be configured for test environments.  

## Details
To use the null cache, simply do something like this:
```ruby
    def init_api
      access_token ||= self.access_token
      opts = {}
...
      opts[:api_cache] = Prismic::BasicNullCache.new
      Prismic.api(config('url'), opts)
    end
```
Obviously, this could be configured in an intializer
```ruby
if Rails.env.test?
  DEFAULT_PRISMIC_API_CACHE = Prismic::BasicNullCache.new
else
  DEFAULT_PRISMIC_API_CACHE = nil
end
```
and then used as `opts[:api_cache] = DEFAULT_PRISMIC_API_CACHE`
