### PR TITLE
Fix caching spec to use cache

### DIFF
--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -72,14 +72,17 @@ describe "Cache's" do
 
     describe 'caching on a real repository' do
       before do
-        @api = Prismic.api("https://lesbonneschoses.prismic.io/api", access_token: 'MC5VbDdXQmtuTTB6Z0hNWHF3.c--_vVbvv73vv73vv73vv71EA--_vS_vv73vv70T77-9Ke-_ve-_vWfvv70ebO-_ve-_ve-_vQN377-9ce-_vRfvv70')
+        @api = Prismic.api("https://lesbonneschoses.prismic.io/api", access_token: 'MC5VbDdXQmtuTTB6Z0hNWHF3.c--_vVbvv73vv73vv73vv71EA--_vS_vv73vv70T77-9Ke-_ve-_vWfvv70ebO-_ve-_ve-_vQN377-9ce-_vRfvv70', cache: Prismic::DefaultCache)
         @cache = @api.cache
+        @cache.should_not be_nil
         @master_ref = @api.master_ref
         @other_ref = @api.refs['announcement of new sf shop']
       end
       it 'works on different refs' do
         @api.form('everything').submit(@master_ref).total_results_size.should == 40
+        @cache.size.should eq(1)
         @api.form('everything').submit(@other_ref).total_results_size.should == 43
+        @cache.size.should eq(2)
       end
     end
   end


### PR DESCRIPTION
The prior version of this spec did not actually use the cache, because when the `:cache` argument is not supplied, the default is not to use the cache.

In working on this I discovered a couple of problems:

1. The documentation [does not clearly state](https://developers.prismic.io/documentation/VBgeDDYAADMAz2Rw/developers-manual#cache) that when you don't supply the `:cache` argument, the default cache won't be used. I think this is reinforced by this test, which was written with the assumption that things will be cached.
2. The documentation states that to implement your own cache, you should implement the interface of Prismic::BasicCache ("You can pass any object implementing the same methods as the BasicCache"). However, the `Prismic::Api#caching` method does not use this interface -- it uses the interface defined by `Prismic::LruCache`. `#get` does not take a block in `BasicCache` and `#get_or_set` does not exist in `LruCache`. This means that if you instantiate the Prismic API like this, it does not work:

```
api = Prismic.api('https://swiftype.prismic.io/api', :access_token => "prismic_access_token", :cache => Prismic::DefaultApiCache)
```

I think this should be fixed, but I'm not sure how you would like to do that. So this PR simply fixes the test so it actually uses the LruCache.
