### PR TITLE
Add Hashery to gemspec

### DIFF
--- a/prismic.gemspec
+++ b/prismic.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'nokogiri', '~> 1.6'
   spec.add_development_dependency 'simplecov', '~> 0.7'
+  spec.add_runtime_dependency 'hashery', '~> 2.1.1'
 end


### PR DESCRIPTION
Hashery was added as a dependency of the LRU Cache.  It's required for runtime.