### PR TITLE
Add i18n functionality

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -461,6 +461,10 @@ module Prismic
     attr_accessor :first_publication_date
     # @return Time
     attr_accessor :last_publication_date
+    # @return [String]
+    attr_accessor :lang
+    # @return [Array<AlternateLanguage>]
+    attr_accessor :alternate_languages
     # @return [Array<Fragment>]
     attr_accessor :fragments
 
@@ -473,6 +477,8 @@ module Prismic
       slugs,
       first_publication_date,
       last_publication_date,
+      lang,
+      alternate_languages,
       fragments
     )
       @id = id
@@ -483,6 +489,8 @@ module Prismic
       @slugs = slugs
       @first_publication_date = first_publication_date
       @last_publication_date = last_publication_date
+      @lang = lang
+      @alternate_languages = alternate_languages
       @fragments = fragments
     end
 
@@ -572,6 +580,28 @@ module Prismic
 
     def serialize(element, content)
       @blk.call(element, content)
+    end
+  end
+  
+
+  # A class for the alternate language versions of a document 
+  #
+  # The {Prismic.alternate_language} function is the recommended way to create an AlternateLanguage.
+  class AlternateLanguage
+    # @return [String]
+    attr_accessor :id
+    # @return [String]
+    attr_accessor :uid
+    # @return [String]
+    attr_accessor :type
+    # @return [String]
+    attr_accessor :lang
+
+    def initialize(json)
+      @id = json['id']
+      @uid = json['uid']
+      @type = json['type']
+      @lang = json['lang']
     end
   end
 

--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -209,6 +209,11 @@ module Prismic
     #   @param  fields [String] The fields separated by commas (,)
     #   @return [SearchForm] self
 
+    # @!method lang(lang)
+    #   Specify a language for this form.
+    #   @param  lang [String] The document language
+    #   @return [SearchForm] self
+
     # Create the fields'helper methods
     def create_field_helper_method(name)
       return if name == 'ref'

--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -569,7 +569,7 @@ module Prismic
       if doc.is_a? Prismic::Fragments::DocumentLink
         @blk.call(doc)
       elsif doc.is_a? Prismic::Document
-        doc_link = Prismic::Fragments::DocumentLink.new(doc.id, doc.uid, doc.type, doc.tags, doc.slug, doc.fragments, false)
+        doc_link = Prismic::Fragments::DocumentLink.new(doc.id, doc.uid, doc.type, doc.tags, doc.slug, doc.lang, doc.fragments, false)
         @blk.call(doc_link)
       end
     end

--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -103,6 +103,9 @@ module Prismic
     # @param opts [Hash] query options (page, pageSize, ref, etc.)
     # @return the document, or nil if not found
     def get_by_id(id, opts={})
+      unless opts.key?("lang")
+        opts["lang"] = '*'
+      end
       query(Prismic::Predicates::at('document.id', id), opts)[0]
     end
     alias :getByID :get_by_id
@@ -113,6 +116,9 @@ module Prismic
     # @param opts [Hash] query options (ref, etc.)
     # @return the document, or nil if not found
     def get_by_uid(typ, uid, opts={})
+      unless opts.key?("lang")
+        opts["lang"] = '*'
+      end
       query(Prismic::Predicates::at('my.'+typ+'.uid', uid), opts)[0]
     end
     alias :getByUID :get_by_uid
@@ -122,6 +128,9 @@ module Prismic
     # @param opts [Hash] query options (page, pageSize, ref, etc.)
     # @return the document, or nil if not found
     def get_by_ids(ids, opts={})
+      unless opts.key?("lang")
+        opts["lang"] = '*'
+      end
       query(Prismic::Predicates::in('document.id', ids), opts)
     end
     alias :getByIDs :get_by_ids
@@ -148,7 +157,7 @@ module Prismic
         return default_url
       end
       json = JSON.load(response.body)
-      documents = self.form('everything').query(Prismic::Predicates.at('document.id', json['mainDocument'])).submit(token)
+      documents = self.form('everything').query(Prismic::Predicates.at('document.id', json['mainDocument'])).lang("*").submit(token)
       if documents.results.size > 0
         link_resolver.link_to(documents.results[0])
       else

--- a/lib/prismic/fragments/link.rb
+++ b/lib/prismic/fragments/link.rb
@@ -96,14 +96,15 @@ module Prismic
 
     class DocumentLink < Link
       include Prismic::WithFragments
-      attr_accessor :id, :uid, :type, :tags, :slug, :fragments, :broken
+      attr_accessor :id, :uid, :type, :tags, :slug, :lang, :fragments, :broken
 
-      def initialize(id, uid, type, tags, slug, fragments, broken)
+      def initialize(id, uid, type, tags, slug, lang, fragments, broken)
         @id = id
         @uid = uid
         @type = type
         @tags = tags
         @slug = slug
+        @lang = lang
         @fragments = fragments
         @broken = broken
       end

--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -221,6 +221,10 @@ module Prismic
         end
       end
 
+      def alternate_language_parser(alternate_language)
+        Prismic::AlternateLanguage.new(alternate_language) 
+      end
+
       def document_parser(json)
         data_json = json['data'].values.first  # {"doc_type": data}
 
@@ -233,6 +237,10 @@ module Prismic
           end
           known_type
         }
+
+        alternate_languages = Hash[json['alternate_languages'].map { |doc| 
+          [doc['lang'], alternate_language_parser(doc)]
+        }]
 
         fragments = Hash[data_json.map { |name, fragment|
           [name, fragment_parser(fragment)]
@@ -247,6 +255,8 @@ module Prismic
             json['slugs'].map { |slug| URI.unescape(slug) },
             json['first_publication_date'] && Time.parse(json['first_publication_date']),
             json['last_publication_date'] && Time.parse(json['last_publication_date']),
+            json['lang'],
+            alternate_languages,
             fragments)
       end
 

--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -48,6 +48,7 @@ module Prismic
           type,
           doc['tags'],
           URI.unescape(doc['slug']),
+          doc['lang'],
           fragments,
           json['value']['isBroken'])
       end
@@ -238,9 +239,12 @@ module Prismic
           known_type
         }
 
-        alternate_languages = Hash[json['alternate_languages'].map { |doc| 
-          [doc['lang'], alternate_language_parser(doc)]
-        }]
+        alternate_languages = nil
+        if json.key?('alternate_languages')
+          alternate_languages = Hash[json['alternate_languages'].map { |doc| 
+            [doc['lang'], alternate_language_parser(doc)]
+          }]
+        end
 
         fragments = Hash[data_json.map { |name, fragment|
           [name, fragment_parser(fragment)]

--- a/spec/fragments_spec.rb
+++ b/spec/fragments_spec.rb
@@ -48,7 +48,7 @@ end
 
 describe 'DocumentLink' do
   before do
-    @document_link = Prismic::Fragments::DocumentLink.new("UdUjvt_mqVNObPeO", nil, "product", ["Macaron"], "dark-chocolate-macaron", {}, false)
+    @document_link = Prismic::Fragments::DocumentLink.new("UdUjvt_mqVNObPeO", nil, "product", ["Macaron"], "dark-chocolate-macaron", "en-us", {}, false)
   end
 
   describe 'url' do
@@ -57,6 +57,12 @@ describe 'DocumentLink' do
     end
     it 'works in a unified way' do
       @document_link.url(@link_resolver).should == 'http://localhost/UdUjvt_mqVNObPeO'
+    end
+  end
+
+  describe 'lang' do
+    it 'is available' do
+      @document_link.lang.should == 'en-us'
     end
   end
 end
@@ -638,6 +644,7 @@ describe 'StructuredText::Hyperlink' do
       "product",
       ["Macaron"],
       "dark-chocolate-macaron",
+      "fr-fr",
       {},
       false  # not broken
     )

--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -11,7 +11,8 @@ describe 'document_link_parser' do
             "id": "UdUjvt_mqVNObPeO",
             "type": "product",
             "tags": ["Macaron"],
-            "slug": "dark-chocolate-macaron"
+            "slug": "dark-chocolate-macaron",
+            "lang": "en-us"
           },
           "isBroken": false
         }
@@ -26,6 +27,7 @@ json
     document_link.type.should == "product"
     document_link.tags.should == ['Macaron']
     document_link.slug.should == "dark-chocolate-macaron"
+    document_link.lang.should == "en-us"
     document_link.broken?.should == false
   end
 end
@@ -361,11 +363,21 @@ describe 'document_parser' do
     @document.href.should == 'doc-url'
     @document.tags.should == ['Macaron']
     @document.slugs.should == ['vanilla-macaron', '南大沢']
+    @document.lang.should == 'en-us'
   end
 
   it "correctly parses the document's publication dates" do
     @document.first_publication_date.should == Time.at(1476845881)
     @document.last_publication_date.should == Time.at(1476846111)
+  end
+
+  it "correctly parses the document's alternate languages" do
+    @document.alternate_languages.size.should == 2
+    @document.alternate_languages['fr-fr'].should be_a Prismic::AlternateLanguage
+    @document.alternate_languages['fr-fr'].id.should == "WL2IziIAACIAem32"
+    @document.alternate_languages['fr-fr'].type.should == "product"
+    @document.alternate_languages['fr-fr'].lang.should == "fr-fr"
+    @document.alternate_languages['fr-fr'].uid.should == nil
   end
 
   it "correctly parses the document's fragments" do

--- a/spec/prismic_spec.rb
+++ b/spec/prismic_spec.rb
@@ -267,30 +267,30 @@ end
 
 describe 'LinkResolver' do
   before do
-    @doc_link = Prismic::Fragments::DocumentLink.new('id', nil, 'blog-post', ['tag1', 'tag2'], 'my-slug', {}, false)
-    @document = Prismic::Document.new('id', nil, 'blog-post', nil, ['tag1', 'tag2'], ['my-slug', 'my-other-slug'], nil, nil, nil)
+    @doc_link = Prismic::Fragments::DocumentLink.new('id', nil, 'blog-post', ['tag1', 'tag2'], 'my-slug', "fr-fr", {}, false)
+    @document = Prismic::Document.new('id', nil, 'blog-post', nil, ['tag1', 'tag2'], ['my-slug', 'my-other-slug'], nil, nil, "en-us", nil, nil)
 
     @link_resolver = Prismic::LinkResolver.new(nil) do |doc|
-      '/'+doc.type+'/'+doc.id+'/'+doc.slug
+      '/'+doc.lang+'/'+doc.type+'/'+doc.id+'/'+doc.slug
     end
   end
 
   it 'builds the right URL from a DocumentLink' do
-    @link_resolver.link_to(@doc_link).should == '/blog-post/id/my-slug'
+    @link_resolver.link_to(@doc_link).should == '/fr-fr/blog-post/id/my-slug'
   end
 
   it 'builds the right URL from a Document' do
-    @link_resolver.link_to(@document).should == '/blog-post/id/my-slug'
+    @link_resolver.link_to(@document).should == '/en-us/blog-post/id/my-slug'
   end
 end
 
 describe 'Document' do
   before do
     fragments = {
-      'field1' => Prismic::Fragments::DocumentLink.new(nil, nil, nil, nil, nil, {}, nil),
+      'field1' => Prismic::Fragments::DocumentLink.new(nil, nil, nil, nil, nil, "fr-fr", {}, nil),
       'field2' => Prismic::Fragments::WebLink.new('weburl')
     }
-    @document = Prismic::Document.new(nil, nil, nil, nil, nil, ['my-slug'], nil, nil, fragments)
+    @document = Prismic::Document.new(nil, nil, nil, nil, nil, ['my-slug'], nil, nil, "fr-fr", nil, fragments)
     @link_resolver = Prismic::LinkResolver.new('master'){|doc_link|
       "http://host/#{doc_link.id}"
     }

--- a/spec/responses_mocks/document.json
+++ b/spec/responses_mocks/document.json
@@ -11,6 +11,19 @@
     "vanilla-macaron",
     "%E5%8D%97%E5%A4%A7%E6%B2%A2"
   ],
+  "lang": "en-us",
+  "alternate_languages": [
+    {
+      "id": "WL6VySoAACwA_H9r",
+      "type": "product",
+      "lang": "es-es"
+    },
+    {
+      "id": "WL2IziIAACIAem32",
+      "type": "product",
+      "lang": "fr-fr"
+    }
+  ],
   "data": {
     "product": {
       "name": {


### PR DESCRIPTION
This PR adds the i18n functionality to this kit. It includes the following changes:
- Adds the lang and alternate_language objects to the document object
- Includes the definition of the lang query function
- Adds a lang wildcard value to the preview query function as well as the query helper functions that return unique documents (get_by_id, get_by_ids, get_by_uid)
- Adds a lang value to document links
- Updates and adds Kit tests for i18n