### PR TITLE
Avoid updating predicates in place.

### DIFF
--- a/lib/prismic.rb
+++ b/lib/prismic.rb
@@ -176,8 +176,9 @@ module Prismic
         end
         predicates = query.map { |predicate|
           predicate.map { |q|
-            op = q.shift
-            "[:d = #{op}(#{q.map { |arg| serialize(arg) }.join(', ')})]"
+            op = q[0]
+            rest = q[1..-1]
+            "[:d = #{op}(#{rest.map { |arg| serialize(arg) }.join(', ')})]"
           }.join('')
         }
         set('q', "[#{predicates * ''}]")

--- a/spec/predicates_spec.rb
+++ b/spec/predicates_spec.rb
@@ -19,6 +19,13 @@ describe 'predicates' do
       form = @api.form('everything').query(Predicates.at('document.id', 'UrjI1gEAALOCeO5i'))
       form.data['q'].should == ['[[:d = at(document.id, "UrjI1gEAALOCeO5i")]]']
     end
+    it 'allows to reuse predicates', focus: true do
+      predicate = Predicates.at('document.id', 'UrjI1gEAALOCeO5i')
+      form = @api.form('everything').query(predicate)
+      form.data['q'].should == ['[[:d = at(document.id, "UrjI1gEAALOCeO5i")]]']
+      form2 = @api.form('everything').query(predicate)
+      form2.data['q'].should == ['[[:d = at(document.id, "UrjI1gEAALOCeO5i")]]']
+    end
   end
 
   describe 'not predicate' do


### PR DESCRIPTION
Predicates in params could no be reused before, as the array was updated
in place.

This should fix this.