### PR TITLE
added as_text to WebLink

### DIFF
--- a/lib/prismic/fragments/link.rb
+++ b/lib/prismic/fragments/link.rb
@@ -33,6 +33,10 @@ module Prismic
         @url = url
       end
 
+      def as_text
+        @url
+      end
+
       # Returns the URL of the link
       #
       # @note The link_resolver parameter is accepted but it is not used by


### PR DESCRIPTION
added an as_text WebLink fragments. it's the url.