### PR TITLE
Fix embed serializer for Rich Text

### DIFF
--- a/lib/prismic/fragments/structured_text.rb
+++ b/lib/prismic/fragments/structured_text.rb
@@ -372,11 +372,27 @@ module Prismic
         end
 
         class Embed < Block
-          attr_accessor :label
+          attr_accessor :embed, :label
 
           def initialize(embed, label)
             @embed = embed
             @label = label
+          end
+
+          def embed_type
+            @embed.embed_type
+          end
+
+          def provider
+            @embed.provider
+          end
+
+          def url
+            @embed.url
+          end
+
+          def html
+            @embed.html
           end
 
           def as_html(link_resolver, html_serializer = nil)

--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -98,14 +98,7 @@ module Prismic
       end
 
       def embed_parser(json)
-        oembed = json['value']['oembed']
-        Prismic::Fragments::Embed.new(
-          oembed['type'],
-          oembed['provider_name'],
-          oembed['provider_url'],
-          oembed['html'],
-          oembed
-        )
+        embed_object_parser(json['value']['oembed'])
       end
 
       def geo_point_parser(json)
@@ -179,17 +172,13 @@ module Prismic
             )
           when 'image'
             Prismic::Fragments::StructuredText::Block::Image.new(
-                view_parser(block),
-                block['label']
+              view_parser(block),
+              block['label']
             )
           when 'embed'
-            boembed = block['oembed']
-            Prismic::Fragments::Embed.new(
-              boembed['type'],
-              boembed['provider_name'],
-              boembed['provider_url'],
-              boembed['html'],
-              boembed
+            Prismic::Fragments::StructuredText::Block::Embed.new(
+              embed_object_parser(block['oembed']),
+              block['label']
             )
           else
             puts "Unknown bloc type: #{block['type']}"
@@ -338,6 +327,16 @@ module Prismic
         elsif json['type'] == 'Link.file'
           file_link_parser(json)
         end
+      end
+
+      def embed_object_parser(json)
+        Prismic::Fragments::Embed.new(
+          json['type'],
+          json['provider_name'],
+          json['provider_url'],
+          json['html'],
+          json
+        )
       end
     end
   end

--- a/spec/micro_spec.rb
+++ b/spec/micro_spec.rb
@@ -11,7 +11,7 @@ describe 'micro' do
   describe 'embed block in structured text fragments' do
     it 'is of the right Embed object, and serializes well' do
       fragment = @api.form('everything').query(%w(at document.id UrjI1gEAALOCeO5i)).submit(@master_ref)[0]['article.body']
-      fragment.blocks[4].is_a?(Prismic::Fragments::Embed).should == true
+      fragment.blocks[4].is_a?(Prismic::Fragments::StructuredText::Block::Embed).should == true
       fragment.as_html(@link_resolver).gsub(/[\n\r]+/, '').gsub(/ +/, ' ').gsub(/&#39;/, "'").should == %(<h2>The meta-micro mailing-list</h2><p>This is where you go to give feedback, and discuss the future of micro. <a href="https://groups.google.com/forum/?hl=en#!forum/micro-meta-framework">Subscribe to the list now</a>!</p><h2>The micro GitHub repository</h2><p>This is where you get truly active, by forking the project's source code, and making it better. Please always feel free to send us pull requests.</p><div data-oembed="" data-oembed-type="link" data-oembed-provider="object"><div data-type="object"><a href="https://github.com/rudyrigot/meta-micro"><h1>rudyrigot/meta-micro</h1><img src="https://avatars2.githubusercontent.com/u/552279?s=400"><p>The meta-micro-framework you simply need</p></a></div></div><h2>Report bugs on micro</h2><p>If you think micro isn't working properly in one of its features, <a href="https://github.com/rudyrigot/meta-micro/issues">open a new issue in the micro GitHub repository</a>.</p><h2>Ask for help</h2><p>Feel free to ask a new question <a href="http://stackoverflow.com/questions/tagged/meta-micro">on StackOverflow</a>.</p>)
     end
   end


### PR DESCRIPTION
This PR fixes the issue where the Embed was serialized as a normal Embed object rather than a Structured Text Block.

This now makes the Embed editable with an HTML Serializer. 