### PR TITLE
Retrieve multiple documents by their uids

### DIFF
--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -135,6 +135,19 @@ module Prismic
     end
     alias :getByIDs :get_by_ids
 
+    # Retrieve multiple documents by their uids
+    # @param typ [String] the document type's name
+    # @param uids [String] the uids to search
+    # @param opts [Hash] query options (ref, etc.)
+
+    def get_by_uids(typ, uids, opts = {})
+      unless opts.key?("lang")
+        opts["lang"] = '*'
+      end
+      query(Prismic::Predicates::in('my.'+typ+'.uid', uids), opts)
+    end
+    alias :getByUIDs :get_by_uids
+    
     # Retrieve one single typed document by its type
     # @param typ [String] the document type's name
     # @param opts [Hash] query options (ref, etc.)


### PR DESCRIPTION
As `uid` field is a unique identifier that can be used specifically to create SEO-friendly website URLs, it should be easy to fetch documents through `get_by_uids` method rather than having to write verbose predicate every time.

Really useful in case we display many but specific documents on a single page.

```ruby
get_by_uids(typ, uids)
```

vs

```ruby
query([
  Prismic::Predicates::at('my.'+typ+'.uid', uids)
])
```