### PR TITLE
Drop old ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
 - jruby-1.7.26
 
 sudo: false
-cache: bundler
 
 script: bundle exec rspec spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 - jruby-1.7.26
 
 sudo: false
-
+before_install: gem install bundler:1.16.0
 script: bundle exec rspec spec
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
 - jruby-1.7.26
 
 sudo: false
+cache: bundler
+
 before_install: gem install bundler:1.16.0
 script: bundle exec rspec spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: ruby
 rvm:
-- 2.4.1
-- 2.3.4
-- 2.2.7
-- 2.1.1
-- 2.1.0
-- 2.0.0
-- 1.9.3
-- jruby-19mode
+- ruby-head
+- 2.6.3
+- 2.5.5
+- 2.4.6
+- jruby-head
+- jruby-9.1.9.0
+- jruby-1.7.26
 
 sudo: false
 cache: bundler


### PR DESCRIPTION
As we wan see there https://bugs.ruby-lang.org/projects/ruby/wiki/ReleaseEngineering , Ruby version below 2.3 included are not maintained anymore. We drop those version from the Travis build and update to latest versions.
We also use head version as informative build (does it build with very latest version ?). 