### PR TITLE
Replace URI.unescape by CGI.unescape

### DIFF
--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'uri'
+require 'cgi'
 
 module Prismic
   module JsonParser
@@ -52,7 +52,7 @@ module Prismic
           doc['uid'],
           type,
           doc['tags'],
-          URI.unescape(doc['slug']),
+          CGI.unescape(doc['slug']),
           doc['lang'],
           fragments,
           json['value']['isBroken'],
@@ -273,7 +273,7 @@ module Prismic
             json['type'],
             json['href'],
             json['tags'],
-            json['slugs'].map { |slug| URI.unescape(slug) },
+            json['slugs'].map { |slug| CGI.unescape(slug) },
             json['first_publication_date'] && Time.parse(json['first_publication_date']),
             json['last_publication_date'] && Time.parse(json['last_publication_date']),
             json['lang'],


### PR DESCRIPTION
Fix for ```URI.unescape``` is obsolete message in Ruby 2.7.