### PR TITLE
Fix NoMethodError

### DIFF
--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'uri'
+require 'time'
 
 module Prismic
   module JsonParser


### PR DESCRIPTION
Fix `undefined method 'parse' for Time:Class (NoMethodError)` by requiring the Time class.

Fixes https://github.com/prismicio/ruby-kit/issues/84.