### PR TITLE
fix: prevent jruby bundler from installing a test library with native extenstion.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       before_install: 
         - gem install bundler -v 2.1.4 -N
       install: 
-        - bundle _2.1.4_ install --jobs=3 --retry=3 --deployment
+        - bundle _2.1.4_ install --jobs=3 --retry=3 
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 # - jruby-head
 
 sudo: false
-cache: bundler
+# cache: bundler
 
 before_install: gem install bundler
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ jobs:
   include:
     - rvm: jruby-head
       before_install: 
-        - rvm @global do gem uninstall bundler -a -x -I || true
-        - gem install bundler -v 2.1.4
+        - gem install bundler -v 2.1.4 --no-rdoc --no-ri
+      install: 
+        - bundle _2.1.4_ install --jobs=3 --retry=3
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
     - rvm: jruby-head
       before_install: 
-        - gem uninstall -i $(rvm gemdir)@global -ax bundler || true
+        - rvm @global do gem uninstall bundler -a -x -I || true
         - gem install bundler -v 2.1.4
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 # - jruby-head
 
 sudo: false
-# cache: bundler
+cache: bundler
 
 before_install: gem install bundler
 script: bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       before_install: 
         - gem install bundler -v 2.1.4 -N
       install: 
-        - bundle _2.1.4_ install --jobs=3 --retry=3
+        - bundle _2.1.4_ install --jobs=3 --retry=3 --deployment
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,18 @@ language: ruby
 rvm:
 - 2.6
 - 2.5
-- jruby-head
+# - jruby-head
 
 sudo: false
 cache: bundler
 
 before_install: gem install bundler
 script: bundle exec rspec spec
+
+jobs:
+  include:
+    - rvm: jruby-head
+      before_install: gem install bundler -v 2.1.4
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
       before_install: 
         - gem install bundler -v 2.1.4 -N
       install: 
-        - bundle _2.1.4_ install --jobs=3 --retry=3 
+        - bundle _2.1.4_ install --jobs=3 --retry=3 --deployment
       script:
         - bundle _2.1.4_ exec rspec spec
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ script: bundle exec rspec spec
 jobs:
   include:
     - rvm: jruby-head
-      before_install: gem install bundler -v 2.1.4
+      before_install: 
+        - gem uninstall -i $(rvm gemdir)@global -ax bundler || true
+        - gem install bundler -v 2.1.4
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
   include:
     - rvm: jruby-head
       before_install: 
-        - gem install bundler -v 2.1.4 --no-rdoc --no-ri
+        - gem install bundler -v 2.1.4 -N
       install: 
         - bundle _2.1.4_ install --jobs=3 --retry=3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
         - gem install bundler -v 2.1.4 -N
       install: 
         - bundle _2.1.4_ install --jobs=3 --retry=3 
+      script:
+        - bundle _2.1.4_ exec rspec spec
 
 notifications:
   email:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,10 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-java)
+      racc (~> 1.4)
     racc (1.5.2)
+    racc (1.5.2-java)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -25,6 +28,7 @@ GEM
     yajl-ruby (1.4.1)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
@@ -32,6 +36,7 @@ DEPENDENCIES
   nokogiri (~> 1.6)
   prismic.io!
   rspec (~> 2.14)
+  rspec-core (~> 2.14)
   yajl-ruby
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,6 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-java)
-      racc (~> 1.4)
     racc (1.5.2)
     racc (1.5.2-java)
     rspec (2.99.0)

--- a/prismic.gemspec
+++ b/prismic.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rspec-core', '~> 2.14'
   spec.add_development_dependency 'nokogiri', '~> 1.6'
   spec.add_runtime_dependency 'hashery', '~> 2.1.1'
 end


### PR DESCRIPTION
there's a dependancy of bundler, `racc` this seems to be creating issues with jruby.

Using bundler -v 2.1.4 worked locally now to test it in travis.