### PR TITLE
fix: null label fallback (release w/o name)

### DIFF
--- a/lib/prismic/api.rb
+++ b/lib/prismic/api.rb
@@ -232,7 +232,7 @@ module Prismic
         }]
         api.refs = Hash[data_refs.map { |ref|
           scheduled_at = ref['scheduledAt']
-          [ref.fetch('label', ref['id']).downcase, Ref.new(ref['id'], ref['ref'], ref['label'], ref['isMasterRef'], scheduled_at && Time.at(scheduled_at / 1000.0))]
+          [(ref['label']&.downcase || ref['id']), Ref.new(ref['id'], ref['ref'], ref['label'], ref['isMasterRef'], scheduled_at && Time.at(scheduled_at / 1000.0))]
         }]
         api.tags = data['tags']
         api.types = data['types']


### PR DESCRIPTION
this undoes the suggestion in
https://github.com/prismicio-community/ruby-kit/pull/128/commits/d54dfecc727f5910e5b3e692496ae2aa1c968315 since it's fundamentally different behavior. `fetch` only fallsback to the second param if the key is missing. but there is a `label` key in our hash, so it returns `nil`, persisting the `nil.downcase` call. This makes it so the value properly falls back when `nil`.

It also doesn't downcase the id since that may actually be case sensitive.

I tested this fix against a codebase reproing the issue and all appears well.

Follow up to https://github.com/prismicio-community/ruby-kit/pull/128, true fix for https://github.com/prismicio-community/ruby-kit/issues/116

@alistairholt pinging you here just because I realized when testing that last PR it didn't quite fix the issue.

Would it be possible to set up CI to run on GitHub actions to ensure the test suite passes before PRs merge? :pray: Happy to lend a hand here if it's something y'all want.